### PR TITLE
[FEAT] Added sensors for sbe41 (Unpumped CTD) and wlbb2f (Wetlabs chi/470/700)

### DIFF
--- a/config/OG1_var_names.yaml
+++ b/config/OG1_var_names.yaml
@@ -30,6 +30,8 @@ vert_speed: GLIDER_VERT_VELO_MODEL
 horz_speed: GLIDER_HORZ_VELO_MODEL
 speed: GLIDE_SPEED
 glide_angle: GLIDE_ANGLE
+depth_avg_curr_east: DAVG_CURR_EAST
+depth_avg_curr_north: DAVG_CURR_NORTH
 adcp_Pressure: PRES_ADCP
 eng_wlbb2f_blueRef: BBP470_REF
 eng_wlbb2f_blueCount: BBP470

--- a/config/OG1_var_names.yaml
+++ b/config/OG1_var_names.yaml
@@ -32,6 +32,7 @@ speed: GLIDE_SPEED
 glide_angle: GLIDE_ANGLE
 depth_avg_curr_east: DAVG_CURR_EAST
 depth_avg_curr_north: DAVG_CURR_NORTH
+depth_avg_curr_qc: DAVG_CURR_EAST_QC
 adcp_Pressure: PRES_ADCP
 eng_wlbb2f_blueRef: BBP470_REF
 eng_wlbb2f_blueCount: BBP470
@@ -67,3 +68,6 @@ eng_pitchCtl: PITCH_CTL
 eng_rollCtl: ROLL_CTL
 eng_vbdCC: VBD_CC
 
+sbe41: Seabird unpumped CTD
+wlbb2f: Wetlabs BB2FL-VMT
+ 

--- a/config/OG1_vocab_attrs.yaml
+++ b/config/OG1_vocab_attrs.yaml
@@ -111,6 +111,11 @@ DAVG_CURR_NORTH:
   observation_type: calculated
   sensor: sensor_ctd, flight_model
   positive: north
+DAVG_CURR_EAST_QC:
+  long_name: depth-averaged current quality control
+  standard_name: status_flag
+  observation_type: quality flag
+  sensor: sensor_ctd, flight_model
 LATITUDE:
   coordinate_reference_frame: urn:ogc:crs:EPSG::4326
   long_name: Latitude north

--- a/config/OG1_vocab_attrs.yaml
+++ b/config/OG1_vocab_attrs.yaml
@@ -97,6 +97,20 @@ VERT_CURR_MODEL:
   sensor: sensor_ctd
   positive: up
   URI: http://vocab.nerc.ac.uk/collection/P01/current/LRZAZZZZ/
+DAVG_CURR_EAST:
+  long_name: depth-averaged current in eastward direction
+  standard_name: eastward_sea_water_velocity
+  units: m s-1
+  observation_type: calculated
+  sensor: sensor_ctd, flight_model
+  positive: east
+DAVG_CURR_NORTH:
+  long_name: depth-averaged current in northward direction
+  standard_name: northward_sea_water_velocity
+  units: m s-1
+  observation_type: calculated
+  sensor: sensor_ctd, flight_model
+  positive: north
 LATITUDE:
   coordinate_reference_frame: urn:ogc:crs:EPSG::4326
   long_name: Latitude north

--- a/seagliderOG1/convertOG1.py
+++ b/seagliderOG1/convertOG1.py
@@ -119,6 +119,7 @@ def process_dataset(ds1):
         - If there are not two surface GPS fixes before a dive, it may inadvertantly turn the whole thing to a dive.
     Checking for valid coordinates: https://github.com/pydata/xarray/issues/3743
     """
+    newdim = vocabularies.dims_rename_dict['sg_data_point']
 
     # Check if the dataset has 'LONGITUDE' as a coordinate
     ds1 = utilities._validate_coords(ds1)
@@ -131,17 +132,25 @@ def process_dataset(ds1):
     divenum = ds1.attrs['dive_number']
     # Split the dataset by unique dimensions
     split_ds = tools.split_by_unique_dims(ds1)
+    ds = split_ds[('sg_data_point',)]
     # Extract the gps_info from the split dataset
     gps_info = split_ds[('gps_info',)]
     # Extract variables starting with 'sg_cal'
     # These will be needed to set attributes for the xarray dataset
     sg_cal, dc_log, dc_other = extract_variables(split_ds[()])
 
+    # Repeat the value of dc_other.depth_avg_curr_east to the length of the dataset
+    var_keep = ['depth_avg_curr_east', 'depth_avg_curr_north']
+    for var in var_keep:
+        if var in dc_other:
+            v1 = dc_other[var].values
+            vector_v = np.full(len(ds['longitude']), v1)
+            ds[var] = (['sg_data_point'], vector_v, dc_other[var].attrs)
     # Rename variables and attributes to OG1 vocabulary
     #-------------------------------------------------------------------
     # Use variables with dimension 'sg_data_point'
     # Must be after split_ds
-    dsa = standardise_OG10(split_ds[('sg_data_point',)])
+    dsa = standardise_OG10(ds)
 
     # Add new variables to the dataset (GPS, divenum, PROFILE_NUMBER, PHASE)
     #-----------------------------------------------------------------------

--- a/seagliderOG1/convertOG1.py
+++ b/seagliderOG1/convertOG1.py
@@ -140,12 +140,13 @@ def process_dataset(ds1):
     sg_cal, dc_log, dc_other = extract_variables(split_ds[()])
 
     # Repeat the value of dc_other.depth_avg_curr_east to the length of the dataset
-    var_keep = ['depth_avg_curr_east', 'depth_avg_curr_north']
+    var_keep = ['depth_avg_curr_east', 'depth_avg_curr_north','depth_avg_curr_qc']
     for var in var_keep:
         if var in dc_other:
             v1 = dc_other[var].values
             vector_v = np.full(len(ds['longitude']), v1)
             ds[var] = (['sg_data_point'], vector_v, dc_other[var].attrs)
+
     # Rename variables and attributes to OG1 vocabulary
     #-------------------------------------------------------------------
     # Use variables with dimension 'sg_data_point'
@@ -166,6 +167,14 @@ def process_dataset(ds1):
     ds_new = tools.assign_phase(ds_new)
     # Assign DEPTH_Z to the dataset where positive is up.
     ds_new = tools.calc_Z(ds_new)
+
+    # Gather sensors
+    sensor_names = ['wlbb2f', 'sbe41']
+    ds_sensor = xr.Dataset()
+    for sensor in sensor_names:
+        if sensor in dc_other:
+            ds_sensor[sensor] = dc_other[sensor]
+    ds_new = tools.add_sensor_to_dataset(ds_new, ds_sensor, sg_cal)
 
     # Remove variables matching vocabularies.vars_to_remove and also 'TIME_GPS'
     vars_to_remove = vocabularies.vars_to_remove + ['TIME_GPS']

--- a/seagliderOG1/utilities.py
+++ b/seagliderOG1/utilities.py
@@ -55,3 +55,33 @@ def _validate_dims(ds):
     dim_name = list(ds.dims)[0] # Should be 'N_MEASUREMENTS' for OG1
     if dim_name != 'N_MEASUREMENTS':
         raise ValueError(f"Dimension name '{dim_name}' is not 'N_MEASUREMENTS'.")
+    
+
+def _parse_calibcomm(calibcomm):
+    print('here')
+    if 'calibration' in calibcomm.values.item().decode('utf-8'):
+        cal_date = calibcomm.values.item().decode('utf-8')[-7:]
+        cal_date_YYYYmmDD = datetime.datetime.strptime(cal_date, '%d%b%y').strftime('%Y%m%d')
+    else:   
+        cal_date_YYYYmmDD = 'Unknown'
+    if 's/n' in calibcomm.values.item().decode('utf-8'):
+        serial_match = re.search(r's/n\s*(\d+)', calibcomm.values.item().decode('utf-8'))
+        serial_number = serial_match.group(0).replace('s/n  ', '').strip()
+    else:
+        serial_number = 'Unknown'
+    print(serial_number)
+
+    return cal_date_YYYYmmDD, serial_number
+
+def _clean_anc_vars_list(ancillary_variables_str):
+    ancillary_variables_str = re.sub(r"(\w)(sg_cal)", r"\1 \2", ancillary_variables_str)
+    ancilliary_vars_list = ancillary_variables_str.split()
+    ancilliary_vars_list = [var.replace('sg_cal_', '') for var in ancilliary_vars_list]
+    return ancilliary_vars_list
+
+def _assign_calval(sg_cal, anc_var_list):
+    calval = {}
+    for anc_var in anc_var_list:
+        var_value = sg_cal[anc_var].values.item()
+        calval[anc_var] = var_value
+    return calval


### PR DESCRIPTION
Addresses #14 

Created `tools.add_sensor_to_dataset()` to parse the sensors available in the basestation files.
- It also calls on the `calibcomm` variable (for CTD) and `sg_cal_constants` values to store serial numbers (if available), calibration dates, and calibration parameters.
- For wlbb2f, the calibration information wasn't available in the original 'sg_calib_constants.m' file, so these are missing.
- For oxygen, no information appears to be in the basestation files even though an oxygen sensor was present.  This will need some future behaviour to handle this case.

New utilities:
- 'utilities._parse_calibcomm()' to read the calibration information out of the string variable
- 'utilities._clean_anc_vars_list()' to identify the ancillary variables needed from 'sg_cal_*' and then extract their values from 'sg_cal' to add to variable attributes
- 'utilities._assign_calval()' to create the dictionary of calibration parameters.

**Also added:** Depth-average currents.

Could add surface currents, but need to decide where in time to assign them - between two of the 3 GPS fixes, but are they the first two or last two (of 3).  Need to check which are closer together in time.