### PR TITLE
[FIX] Change environment name to release in pypi.yml

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,9 +21,7 @@ permissions:
 jobs:
   release-build:
     runs-on: ubuntu-latest
-    environment: 
-      name: release
-      url: https://pypi.org/project/seagliderOG1/
+    environment: release
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ jobs:
   release-build:
     runs-on: ubuntu-latest
     environment: 
-      name: TEST
+      name: release
       url: https://pypi.org/project/seagliderOG1/
     permissions:
       id-token: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ dependencies = { file = [
 ] }
 readme = { file = "README.md", content-type = "text/markdown" }
 
+[tool.setuptools_scm]
+write_to = "seagliderOG1/_version.py"
+write_to_template = "__version__ = '{version}'"
+tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
+
 [tool.check-manifest]
 ignore = [
   "docs",


### PR DESCRIPTION
Setting environment name to match name expected in https://pypi.org/project/seagliderOG1/ as `release`.